### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -11,9 +11,9 @@ ESP32CAN	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-CANInit    KEYWORD2
-CANWriteFrame KEYWORD2
-CANStop    KEYWORD2
+CANInit	KEYWORD2
+CANWriteFrame	KEYWORD2
+CANStop	KEYWORD2
 CANConfigFilter	KEYWORD2
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords