### PR TITLE
CAN configuration is passed to the constructor as an argument

### DIFF
--- a/examples/esp32can_basic/esp32can_basic.ino
+++ b/examples/esp32can_basic/esp32can_basic.ino
@@ -15,7 +15,7 @@ void setup() {
   CAN_cfg.rx_pin_id = GPIO_NUM_4;
   CAN_cfg.rx_queue = xQueueCreate(rx_queue_size, sizeof(CAN_frame_t));
   // Init CAN Module
-  ESP32Can.CANInit();
+  ESP32Can.CANInit(CAN_cfg);
 }
 
 void loop() {

--- a/examples/esp32can_filter/esp32can_filter.ino
+++ b/examples/esp32can_filter/esp32can_filter.ino
@@ -32,7 +32,7 @@ void setup() {
   ESP32Can.CANConfigFilter(&p_filter);
 
   // Init CAN Module
-  ESP32Can.CANInit();
+  ESP32Can.CANInit(CAN_cfg);
 }
 
 void loop() {
@@ -63,4 +63,3 @@ void loop() {
     }
   }
 }
-

--- a/examples/esp32can_mirror/esp32can_mirror.ino
+++ b/examples/esp32can_mirror/esp32can_mirror.ino
@@ -13,7 +13,7 @@ void setup() {
   CAN_cfg.rx_pin_id = GPIO_NUM_4;
   CAN_cfg.rx_queue = xQueueCreate(rx_queue_size, sizeof(CAN_frame_t));
   // Init CAN Module
-  ESP32Can.CANInit();
+  ESP32Can.CANInit(CAN_cfg);
 }
 
 void loop() {

--- a/src/CAN.c
+++ b/src/CAN.c
@@ -45,6 +45,7 @@
 
 // CAN Filter - no acceptance filter
 static CAN_filter_t __filter = { Dual_Mode, 0, 0, 0, 0, 0Xff, 0Xff, 0Xff, 0Xff };
+static CAN_device_t __CAN_cfg;
 
 static void CAN_read_frame_phy();
 static void CAN_isr(void *arg_p);
@@ -90,7 +91,7 @@ static void CAN_read_frame_phy(BaseType_t *higherPriorityTaskWoken) {
 	CAN_frame_t __frame;
 
 	// check if we have a queue. If not, operation is aborted.
-	if (CAN_cfg.rx_queue == NULL) {
+	if (__CAN_cfg.rx_queue == NULL) {
 		// Let the hardware know the frame has been read.
 		MODULE_CAN->CMR.B.RRB = 1;
 		return;
@@ -122,7 +123,7 @@ static void CAN_read_frame_phy(BaseType_t *higherPriorityTaskWoken) {
 	}
 
 	// send frame to input queue
-	xQueueSendToBackFromISR(CAN_cfg.rx_queue, &__frame, higherPriorityTaskWoken);
+	xQueueSendToBackFromISR(__CAN_cfg.rx_queue, &__frame, higherPriorityTaskWoken);
 
 	// Let the hardware know the frame has been read.
 	MODULE_CAN->CMR.B.RRB = 1;
@@ -164,8 +165,8 @@ static int CAN_write_frame_phy(const CAN_frame_t *p_frame) {
 	return 0;
 }
 
-int CAN_init() {
-
+int CAN_init(const CAN_device_t p_CAN_cfg) {
+	__CAN_cfg = p_CAN_cfg;
 	// Time quantum
 	double __tq;
 
@@ -174,15 +175,15 @@ int CAN_init() {
 	DPORT_CLEAR_PERI_REG_MASK(DPORT_PERIP_RST_EN_REG, DPORT_CAN_RST);
 
 	// configure TX pin
-	gpio_set_level(CAN_cfg.tx_pin_id, 1);
-	gpio_set_direction(CAN_cfg.tx_pin_id, GPIO_MODE_OUTPUT);
-	gpio_matrix_out(CAN_cfg.tx_pin_id, CAN_TX_IDX, 0, 0);
-	gpio_pad_select_gpio(CAN_cfg.tx_pin_id);
+	gpio_set_level(__CAN_cfg.tx_pin_id, 1);
+	gpio_set_direction(__CAN_cfg.tx_pin_id, GPIO_MODE_OUTPUT);
+	gpio_matrix_out(__CAN_cfg.tx_pin_id, CAN_TX_IDX, 0, 0);
+	gpio_pad_select_gpio(__CAN_cfg.tx_pin_id);
 
 	// configure RX pin
-	gpio_set_direction(CAN_cfg.rx_pin_id, GPIO_MODE_INPUT);
-	gpio_matrix_in(CAN_cfg.rx_pin_id, CAN_RX_IDX, 0);
-	gpio_pad_select_gpio(CAN_cfg.rx_pin_id);
+	gpio_set_direction(__CAN_cfg.rx_pin_id, GPIO_MODE_INPUT);
+	gpio_matrix_in(__CAN_cfg.rx_pin_id, CAN_RX_IDX, 0);
+	gpio_pad_select_gpio(__CAN_cfg.rx_pin_id);
 
 	// set to PELICAN mode
 	MODULE_CAN->CDR.B.CAN_M = 0x1;
@@ -194,7 +195,7 @@ int CAN_init() {
 	MODULE_CAN->BTR1.B.TSEG2 = 0x1;
 
 	// select time quantum and set TSEG1
-	switch (CAN_cfg.speed) {
+	switch (__CAN_cfg.speed) {
 	case CAN_SPEED_1000KBPS:
 		MODULE_CAN->BTR1.B.TSEG1 = 0x4;
 		__tq = 0.125;
@@ -213,7 +214,7 @@ int CAN_init() {
 
 	default:
 		MODULE_CAN->BTR1.B.TSEG1 = 0xc;
-		__tq = ((float) 1000 / CAN_cfg.speed) / 16;
+		__tq = ((float) 1000 / __CAN_cfg.speed) / 16;
 	}
 
 	// set baud rate prescaler

--- a/src/CAN.h
+++ b/src/CAN.h
@@ -98,7 +98,7 @@ typedef struct {
  *
  * \return 0 CAN Module had been initialized
  */
-int CAN_init(void);
+int CAN_init(const CAN_device_t p_CAN_cfg);
 
 /**
  * \brief Send a can frame

--- a/src/CAN_config.h
+++ b/src/CAN_config.h
@@ -61,9 +61,6 @@ typedef struct {
 	TaskHandle_t rx_handle; /**< \brief Handler to FreeRTOS RX task. */
 } CAN_device_t;
 
-/** \brief CAN configuration reference */
-extern CAN_device_t CAN_cfg;
-
 #ifdef __cplusplus
 }
 #endif

--- a/src/ESP32CAN.cpp
+++ b/src/ESP32CAN.cpp
@@ -1,8 +1,8 @@
 #include "ESP32CAN.h"
 
-int ESP32CAN::CANInit()
+int ESP32CAN::CANInit(const CAN_device_t p_CAN_cfg)
 {
-    return CAN_init();
+    return CAN_init(p_CAN_cfg);
 }
 int ESP32CAN::CANWriteFrame(const CAN_frame_t* p_frame)
 {

--- a/src/ESP32CAN.h
+++ b/src/ESP32CAN.h
@@ -7,8 +7,8 @@
 class ESP32CAN
 {
     public: 
-        int CANInit();
-		int CANConfigFilter(const CAN_filter_t* p_filter);
+        int CANInit(const CAN_device_t p_CAN_cfg);
+        int CANConfigFilter(const CAN_filter_t* p_filter);
         int CANWriteFrame(const CAN_frame_t* p_frame);
         int CANStop();
 };


### PR DESCRIPTION
The CAN configuration is passed as an argument to the constructor. The examples are only changed at that line but github somehow fails to detect it (maybe because of the EOL character differences)