### PR TITLE
Resolve the busheavy issue when the ESP32 chip revision >=2

### DIFF
--- a/src/CAN.c
+++ b/src/CAN.c
@@ -29,6 +29,7 @@
  *
  */
 
+#include "esp_system.h"
 #include "CAN.h"
 
 #include "freertos/FreeRTOS.h"
@@ -227,6 +228,14 @@ int CAN_init() {
 
 	// enable all interrupts
 	MODULE_CAN->IER.U = 0xff;
+
+	esp_chip_info_t chip_info;
+    esp_chip_info(&chip_info);
+    if(chip_info.revision >=2){
+        // disable wake-up interrupt
+		// refer to https://github.com/sandeepmistry/arduino-CAN/issues/75 for the original information
+        MODULE_CAN->IER.B.WUIE = 0x0;
+    }	
 
 	 // Set acceptance filter	
 	MODULE_CAN->MOD.B.AFM = __filter.FM;	


### PR DESCRIPTION
Issue: Not Working with ESP Wroom32 chip revision >=2
Resolved this issue by disabling wake-up interrupt.