### PR TITLE
Added support for Rev 3 ESP32 boards

### DIFF
--- a/src/CAN.c
+++ b/src/CAN.c
@@ -226,7 +226,7 @@ int CAN_init() {
 	MODULE_CAN->BTR1.B.SAM = 0x1;
 
 	// enable all interrupts
-	MODULE_CAN->IER.U = 0xff;
+	MODULE_CAN->IER.U = 0xef;
 
 	 // Set acceptance filter	
 	MODULE_CAN->MOD.B.AFM = __filter.FM;	


### PR DESCRIPTION
With the current implementation it works fine for Rev1 & 2 ESP32 boards, but the newer Rev 3 ESP32 boards do not work. This fixes that. More information can be found here if you are interested https://github.com/espressif/arduino-esp32/issues/7723