### PR TITLE
Make library compatible with 3.0.0 ESP32

### DIFF
--- a/src/CAN.c
+++ b/src/CAN.c
@@ -34,7 +34,7 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
 
-#include "esp_intr.h"
+#include "esp_intr_alloc.h"
 #include "soc/dport_reg.h"
 #include <math.h>
 
@@ -42,6 +42,9 @@
 
 #include "can_regdef.h"
 #include "CAN_config.h"
+
+#define TWAI_TX_IDX 123
+#define TWAI_RX_IDX 94
 
 // CAN Filter - no acceptance filter
 static CAN_filter_t __filter = { Dual_Mode, 0, 0, 0, 0, 0Xff, 0Xff, 0Xff, 0Xff };
@@ -176,12 +179,12 @@ int CAN_init() {
 	// configure TX pin
 	gpio_set_level(CAN_cfg.tx_pin_id, 1);
 	gpio_set_direction(CAN_cfg.tx_pin_id, GPIO_MODE_OUTPUT);
-	gpio_matrix_out(CAN_cfg.tx_pin_id, CAN_TX_IDX, 0, 0);
+	gpio_matrix_out(CAN_cfg.tx_pin_id, TWAI_TX_IDX, 0, 0);
 	gpio_pad_select_gpio(CAN_cfg.tx_pin_id);
 
 	// configure RX pin
 	gpio_set_direction(CAN_cfg.rx_pin_id, GPIO_MODE_INPUT);
-	gpio_matrix_in(CAN_cfg.rx_pin_id, CAN_RX_IDX, 0);
+	gpio_matrix_in(CAN_cfg.rx_pin_id, TWAI_RX_IDX, 0);
 	gpio_pad_select_gpio(CAN_cfg.rx_pin_id);
 
 	// set to PELICAN mode


### PR DESCRIPTION
### What
This PR fixes the issues encountered when upgrading from from Espressif versions 2.X.X (based on ESP-IDF 4.4) to version 3.0.0 (based on ESP-IDF 5.1) of the Arduino ESP32 core

### Why
3.0.0 is the new default, which breaks support for this library

### How
You can manually update your version of ESP32 to 3.0.0, it can be done here in the Arduino IDE:
![334774954-2c1eee53-aa30-40ff-bd74-a0af423119be](https://github.com/miwagner/ESP32-Arduino-CAN/assets/26695010/f6154f04-1d4f-47b7-bba9-56d4ec1269ae)
