### PR TITLE
match espressif 3.0.3 Update 

### DIFF
--- a/src/CAN.c
+++ b/src/CAN.c
@@ -34,8 +34,9 @@
 #include "freertos/FreeRTOS.h"
 #include "freertos/queue.h"
 
-#include "esp_intr.h"
+#include "esp_intr_alloc.h"
 #include "soc/dport_reg.h"
+#include "soc/gpio_sig_map.h"
 #include <math.h>
 
 #include "driver/gpio.h"
@@ -176,12 +177,12 @@ int CAN_init() {
 	// configure TX pin
 	gpio_set_level(CAN_cfg.tx_pin_id, 1);
 	gpio_set_direction(CAN_cfg.tx_pin_id, GPIO_MODE_OUTPUT);
-	gpio_matrix_out(CAN_cfg.tx_pin_id, CAN_TX_IDX, 0, 0);
+	gpio_matrix_out(CAN_cfg.tx_pin_id, TWAI_TX_IDX, 0, 0);
 	gpio_pad_select_gpio(CAN_cfg.tx_pin_id);
 
 	// configure RX pin
 	gpio_set_direction(CAN_cfg.rx_pin_id, GPIO_MODE_INPUT);
-	gpio_matrix_in(CAN_cfg.rx_pin_id, CAN_RX_IDX, 0);
+	gpio_matrix_in(CAN_cfg.rx_pin_id, TWAI_RX_IDX, 0);
 	gpio_pad_select_gpio(CAN_cfg.rx_pin_id);
 
 	// set to PELICAN mode
@@ -197,7 +198,8 @@ int CAN_init() {
 	switch (CAN_cfg.speed) {
 	case CAN_SPEED_1000KBPS:
 		MODULE_CAN->BTR1.B.TSEG1 = 0x4;
-		__tq = 0.125;
+		MODULE_CAN->BTR1.B.TSEG2 = 0x3;
+		__tq = 0.0625;
 		break;
 
 	case CAN_SPEED_800KBPS:
@@ -217,6 +219,7 @@ int CAN_init() {
 	}
 
 	// set baud rate prescaler
+	//MODULE_CAN->BTR0.B.BRP = (uint8_t) round((((APB_CLK_FREQ * __tq) / 2) - 1) / 1000000) - 1;
 	MODULE_CAN->BTR0.B.BRP = (uint8_t) round((((APB_CLK_FREQ * __tq) / 2) - 1) / 1000000) - 1;
 
 	/* Set sampling


### PR DESCRIPTION
In the recent 3.0.x Board Library Update from Espressif the constants CAN_TX_ID and CAN_RX_IDX have been renamed to TWAI_RX_IDX/TWAI_TX_IDX and the define moved to #include "soc/gpio_sig_map.h". 
I adapted the source to match these changes. 

I also put in a timing fix for 1Mbps BAud rate. 